### PR TITLE
iss26-ai-reroute-typo-state 

### DIFF
--- a/web/components/Header/Header.tsx
+++ b/web/components/Header/Header.tsx
@@ -42,9 +42,6 @@ const Header: React.FC<HeaderProps> = ({ selectedState, onStateChange }) => {
     // Convert to URL format when passing to parent
     onStateChange(formatStateForUrl(state));
     setIsDropdownOpen(false);
-    if (state == "Minnesota") {
-      window.open('https://invisible.institute/mnpost', '_blank')
-    }
   };
 
   const handleAboutClick = () => {

--- a/web/pages/api/fetchStateData.ts
+++ b/web/pages/api/fetchStateData.ts
@@ -185,7 +185,7 @@ export default async function handler(
 
   try {
     const formattedState = state.toLowerCase().replace(/\s+/g, '-');
-    if (formattedState === 'minnesota') {
+    if (formattedState === 'minneapolis') {
       return res.status(200).json({
         data: [],
         currentPage: 1,

--- a/web/pages/index.tsx
+++ b/web/pages/index.tsx
@@ -8,13 +8,7 @@ export default function Home() {
   const router = useRouter();
 
   const handleStateSelection = (state: string) => {
-    // The state name is already formatted for URL when it arrives here
-    if (state == 'Minnesota') {
-      window.open('https://invisible.institute/mnpost', '_blank')
-    }
-    else {
       router.push(`/state/${state}`);
-    }
   };
 
   return (


### PR DESCRIPTION
Last week we removed the Minnesota data from our db because of data quality issues associated with the state's POST agency. Because @tarakc02 has cleaned and pushed the new data that we received, this PR is intended to again route users to the Minnesota table, rather than the Invisible Insitute's website. 

Before:

<img width="1508" alt="Screenshot 2025-01-26 at 9 22 59 PM" src="https://github.com/user-attachments/assets/37b73563-bd90-4d64-b7da-f877237be918" />

After:

<img width="1512" alt="Screenshot 2025-01-26 at 9 23 24 PM" src="https://github.com/user-attachments/assets/f0c20f8d-31f6-4e42-a6d5-79cd9f2c4231" />
